### PR TITLE
Add support for json traces API

### DIFF
--- a/app/controllers/api/traces_controller.rb
+++ b/app/controllers/api/traces_controller.rb
@@ -1,6 +1,7 @@
 module Api
   class TracesController < ApiController
     before_action :check_api_writable, :only => [:create, :update, :destroy]
+    before_action :set_request_formats, :only => [:show]
     before_action :set_locale
     before_action :authorize
 
@@ -12,7 +13,14 @@ module Api
     def show
       @trace = Trace.visible.find(params[:id])
 
-      head :forbidden unless @trace.public? || @trace.user == current_user
+      if @trace.public? || @trace.user == current_user
+        respond_to do |format|
+          format.xml
+          format.json
+        end
+      else
+        head :forbidden
+      end
     end
 
     def create

--- a/app/controllers/api/users/traces_controller.rb
+++ b/app/controllers/api/users/traces_controller.rb
@@ -2,12 +2,16 @@ module Api
   module Users
     class TracesController < ApiController
       before_action :authorize
+      before_action :set_request_formats, :only => [:index]
 
       authorize_resource :trace
 
       def index
         @traces = current_user.traces.reload
-        render :content_type => "application/xml"
+        respond_to do |format|
+          format.xml
+          format.json
+        end
       end
     end
   end

--- a/app/views/api/traces/_trace.json.jbuilder
+++ b/app/views/api/traces/_trace.json.jbuilder
@@ -1,0 +1,15 @@
+json.id trace.id
+json.name trace.name
+json.uid trace.user_id
+json.user trace.user.display_name
+json.visibility trace.visibility
+json.pending !trace.inserted
+json.timestamp trace.timestamp.xmlschema
+
+if trace.inserted
+  json.lat trace.latitude
+  json.lon trace.longitude
+end
+
+json.description trace.description
+json.tags trace.tags.map(&:tag)

--- a/app/views/api/traces/show.json.jbuilder
+++ b/app/views/api/traces/show.json.jbuilder
@@ -1,0 +1,5 @@
+json.partial! "api/root_attributes"
+
+json.trace do
+  json.partial! "api/traces/trace", :trace => @trace
+end

--- a/app/views/api/users/traces/index.json.jbuilder
+++ b/app/views/api/users/traces/index.json.jbuilder
@@ -1,0 +1,5 @@
+json.partial! "api/root_attributes"
+
+json.traces @traces do |trace|
+  json.partial! "api/traces/trace", :trace => trace
+end

--- a/test/controllers/api/users/traces_controller_test.rb
+++ b/test/controllers/api/users/traces_controller_test.rb
@@ -10,6 +10,10 @@ module Api
           { :path => "/api/0.6/user/gpx_files", :method => :get },
           { :controller => "api/users/traces", :action => "index" }
         )
+        assert_routing(
+          { :path => "/api/0.6/user/gpx_files.json", :method => :get },
+          { :controller => "api/users/traces", :action => "index", :format => "json" }
+        )
       end
 
       def test_index
@@ -34,6 +38,16 @@ module Api
         assert_select "gpx_file[id='#{trace2.id}']", 1 do
           assert_select "tag", "Birmingham"
         end
+
+        # check that we get a response when logged in with json
+        auth_header = bearer_authorization_header user, :scopes => %w[read_gpx]
+        get api_user_traces_path(:format => "json"), :headers => auth_header
+        assert_response :success
+        assert_equal "application/json", response.media_type
+        js = ActiveSupport::JSON.decode(@response.body)
+        assert_not_nil js
+        assert_equal trace1.id, js["traces"][0]["id"]
+        assert_equal trace2.id, js["traces"][1]["id"]
       end
 
       def test_index_anonymous


### PR DESCRIPTION
Update app/controllers/api/traces_controller.rb

Co-authored-by: Tom Hughes <tom@compton.nu>

Fix rubocop errors

Remove unneeded content type definition

Added routing and json tests

Add format to test where it was missing

Add missing request formats definition

<!--
Please read the contributing guidelines before making a PR:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md

Pay particular attention to the section on how to present PRs:
  https://github.com/openstreetmap/openstreetmap-website/blob/master/CONTRIBUTING.md#pull-requests
-->

### Description
<!--Describe your changes in detail. If you have made changes to the UI, include screenshots. If your PR addresses a Github issue, please link to it.-->

### How has this been tested?
<!--Explain the steps you took to test your code.-->
